### PR TITLE
Add ItemDisplayBinding to Picker for product names

### DIFF
--- a/Grocery.App/Views/BoughtProductsView.xaml
+++ b/Grocery.App/Views/BoughtProductsView.xaml
@@ -18,6 +18,7 @@
         <Picker Grid.Column="0" Grid.Row="0" Margin="10,0,0,0" Title="Klik op onderstaand pijltje om een product te selecteren:"
         ItemsSource="{Binding Products}"
         SelectedItem="{Binding SelectedProduct, Mode=TwoWay}" 
+        ItemDisplayBinding="{Binding Name}"
         SelectedIndexChanged="Picker_SelectedIndexChanged"
         BackgroundColor="{StaticResource Primary}"
             TextColor="{StaticResource Secondary}">


### PR DESCRIPTION
Right now the Picker shows the type name (App.Core.Data.Models.Product) because by default .NET MAUI calls .ToString() on the object if you don’t tell it which property to display.